### PR TITLE
Aggregate retail by sellable ID

### DIFF
--- a/Website - Product Pricing Python.py
+++ b/Website - Product Pricing Python.py
@@ -91,8 +91,20 @@ try:
     grouped['Regions'] = grouped['Regions'].apply(flag_all)
 
     # --------------------------------------------------------------
+    # 7. Combine Retail and Region pairs per Sellable ID
+    grouped['Retail_Regions'] = grouped.apply(
+        lambda row: f"{row['Retail']:.2f} - {row['Regions']}", axis=1
+    )
+    final_df = (
+        grouped
+        .groupby('Sellable ID')['Retail_Regions']
+        .apply('; '.join)
+        .reset_index(name='Retail - Regions')
+    )
+
+    # --------------------------------------------------------------
     # Export results to Excel
-    grouped.to_excel(output_path, index=False)
+    final_df.to_excel(output_path, index=False)
     print(f"Export successful! File saved to: {output_path}")
 
     # Automatically open the file (Windows)


### PR DESCRIPTION
## Summary
- group retail and regions by Sellable ID for Website Product Pricing output

## Testing
- `python3 "Website - Product Pricing Python.py"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2d8da648333bf062ca783e026e7