### PR TITLE
Extend dashboard with SAP store data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ These scripts were created for data analysis and reporting purposes. They query 
    which connects to server `5909z0ndbsrvt02` and the `BIRD_IDS_D` database using
    ODBC. This script exports query results to Excel and can be adapted for other
    SQL statements.
-5. To extract online listings you must run `Website - SAP - All Listings` in SAP HANA Studio and export the results to an `.xlsx` file.
+5. To extract online listings you must run `Website - SAP - All Listings` in SAP HANA Studio and export the results to an `.xlsx` file named `SAP Listings.xlsx`.
 
 Some scripts reference multiple schemas or require the connection to be set to the correct database. Adjust any schema references if needed before running.
 
@@ -57,7 +57,7 @@ Some scripts reference multiple schemas or require the connection to be set to t
 | Website Dashboard BD SQL Info.txt | Extracts data used on the BD website dashboard |
 | Website - Python SQL Script Test | Example Python script using ODBC to query BIRD_IDS_D on server 5909z0ndbsrvt02 and export results to Excel |
 | Website - Website Dashboard HTML.py | Generates an interactive offline dashboard as an HTML file |
-| Website - Website Dashboard Python.py | Creates the Excel dashboard with product, location, and price data |
+| Website - Website Dashboard Python.py | Creates the Excel dashboard with product, location, and price data. Expects `SAP Listings.xlsx` in the same folder |
 | Website - Product Pricing Python.py | Generates region-based pricing summary from CSV inputs |
 | Website - SAP - All Listings | SAP HANA SQL listing all store assignments for online products |
 | Website - SAP Export For Grant - E41.txt | SAP HANA query providing E41 export data for Grant |

--- a/Website - Website Dashboard Python.py
+++ b/Website - Website Dashboard Python.py
@@ -16,6 +16,7 @@ BASE_DIR = r'C:\Users\dmccrea\Documents\Python Scripts\New folder'
 PRICING_CSV = os.path.join(BASE_DIR, 'AU_product_offer_price_en_AU.csv')
 PRODUCTS_CSV = os.path.join(BASE_DIR, 'AU_products_en_AU.csv')
 IMAGES_CSV = os.path.join(BASE_DIR, 'AU_product_image_en_AU.csv')
+SAP_LISTINGS_XLSX = os.path.join(BASE_DIR, 'Website - SAP - All Listings.xlsx')
 
 # SQL Server connection parameters
 SERVER = '5909z0ndbsrvt02'
@@ -178,6 +179,37 @@ def load_product_images():
     return df[['SellableID']].dropna()
 
 
+def load_sap_store_counts():
+    """Return DataFrame with SAP store count and sample stores per sellable ID."""
+    if not os.path.exists(SAP_LISTINGS_XLSX):
+        return pd.DataFrame(columns=['SellableID', 'SAP_Count', 'StoreSample'])
+
+    df = pd.read_excel(SAP_LISTINGS_XLSX, dtype=str)
+    df.columns = [c.strip() for c in df.columns]
+    if not df.columns.empty:
+        df.rename(columns={df.columns[0]: 'ProductCode'}, inplace=True)
+
+    store_cols = [c for c in df.columns if 'stores' in c.lower()]
+
+    def parse_row(row):
+        stores = []
+        for col in store_cols:
+            val = row.get(col)
+            if pd.isna(val):
+                continue
+            for s in str(val).split(','):
+                s = s.strip().lstrip('0')
+                if s:
+                    stores.append(s)
+        return stores
+
+    df['StoreList'] = df.apply(parse_row, axis=1)
+    df['SAP_Count'] = df['StoreList'].apply(lambda x: len(set(x)))
+    df['StoreSample'] = df['StoreList'].apply(lambda x: ', '.join(x[:10]))
+    df['SellableID'] = pd.to_numeric(df['ProductCode'].str.lstrip('0'), errors='coerce').astype('Int64')
+    return df[['SellableID', 'SAP_Count', 'StoreSample']]
+
+
 def build_dashboard(df_catalog, df_location, df_gp, df_price, df_images):
     df = df_catalog.merge(
         df_location,
@@ -306,6 +338,23 @@ def main():
         images_df = load_product_images()
         final_df = build_dashboard(catalog, location_data, gp_info, pricing_data, images_df)
 
+        sap_counts = load_sap_store_counts()
+        final_df = final_df.merge(
+            sap_counts,
+            left_on='Sellable ID',
+            right_on='SellableID',
+            how='left'
+        ).drop(columns=['SellableID'])
+        final_df = final_df.rename(columns={'SAP_Count': 'Stores Listed in SAP', 'StoreSample': 'SAP Store Sample'})
+
+        mismatch_counts = final_df[
+            final_df['Stores Listed in SAP'] != final_df['Available in Stores (Count)']
+        ][[
+            'SAP BD', 'Sellable ID', 'Available in Stores (Count)',
+            'Stores Listed in SAP', 'SAP Store Sample'
+        ]]
+        final_df = final_df.drop(columns=['SAP Store Sample'])
+
         # Determine most common store count per region combination
         mode_map = (final_df.groupby('Regions On Website')['Available in Stores (Count)']
                     .agg(lambda x: x.mode().iat[0] if not x.mode().empty else None))
@@ -332,7 +381,7 @@ def main():
          # Append helper column for formatting
         column_order = [
             'SAP BD', 'Sellable ID', 'Website Product Name', 'SAP Product Name',
-            'Regions On Website', 'Available in Stores (Count)',
+            'Regions On Website', 'Available in Stores (Count)', 'Stores Listed in SAP',
             'Retail by Region (updated weekly)', 'Product Description',
             'Legal Disclaimer', 'Image Status', 'Hierarchy',
             'SAP Commodity Group', 'SAP Sub Commodity Group',
@@ -357,20 +406,22 @@ def main():
             'D': 35,
             'E': 19,
             'F': 20,
-            'g': 27,
-            'H': 86,  # Product Description
-            'I': 71,  # Legal Disclaimer
-            'J': 15,
+            'G': 20,
+            'H': 27,
+            'I': 86,  # Product Description
+            'J': 71,  # Legal Disclaimer
             'K': 15,
             'L': 15,
             'M': 15,
             'N': 15,
             'O': 15,
             'P': 15,
+            'Q': 15,
+            'R': 15,
         }
         for col, width in width_map.items():
             ws.column_dimensions[col].width = width
-        for cell in ws['H']:
+        for cell in ws['I']:
             cell.alignment = Alignment(wrap_text=True)
 
         # Grey out rows with no stores
@@ -387,6 +438,11 @@ def main():
         rule.formula = [f"${dev_col}2"]
         count_col = get_column_letter([c.value for c in ws[1]].index('Available in Stores (Count)') + 1)
         ws.conditional_formatting.add(f"{count_col}2:{count_col}{ws.max_row}", rule)
+
+        sap_col = get_column_letter([c.value for c in ws[1]].index('Stores Listed in SAP') + 1)
+        rule = Rule(type='expression', dxf=DifferentialStyle(fill=yellow_fill))
+        rule.formula = [f"${sap_col}2<>${count_col}2"]
+        ws.conditional_formatting.add(f"{sap_col}2:{sap_col}{ws.max_row}", rule)
 
         # Highlight multiple prices
         multi_col = get_column_letter([c.value for c in ws[1]].index('Multiple Prices') + 1)
@@ -442,6 +498,12 @@ def main():
             for r in dataframe_to_rows(mismatch_df, index=False, header=True):
                 mis_ws.append(r)
             mis_ws.auto_filter.ref = mis_ws.dimensions
+
+        if not mismatch_counts.empty:
+            samp_ws = wb.create_sheet('Mismatch Samples')
+            for r in dataframe_to_rows(mismatch_counts, index=False, header=True):
+                samp_ws.append(r)
+            samp_ws.auto_filter.ref = samp_ws.dimensions
 
         wb.save(output_path)
         print(f"Export successful! File saved to: {output_path}")

--- a/Website - Website Dashboard Python.py
+++ b/Website - Website Dashboard Python.py
@@ -16,7 +16,7 @@ BASE_DIR = r'C:\Users\dmccrea\Documents\Python Scripts\New folder'
 PRICING_CSV = os.path.join(BASE_DIR, 'AU_product_offer_price_en_AU.csv')
 PRODUCTS_CSV = os.path.join(BASE_DIR, 'AU_products_en_AU.csv')
 IMAGES_CSV = os.path.join(BASE_DIR, 'AU_product_image_en_AU.csv')
-SAP_LISTINGS_XLSX = os.path.join(BASE_DIR, 'Website - SAP - All Listings.xlsx')
+SAP_LISTINGS_XLSX = os.path.join(BASE_DIR, 'SAP Listings.xlsx')
 
 # SQL Server connection parameters
 SERVER = '5909z0ndbsrvt02'
@@ -31,6 +31,16 @@ CONN_STR = (
 )
 
 EXPECTED_REGIONS = ['BRE', 'DAN', 'DER', 'JKT', 'MIN', 'PRE', 'RGY', 'STP']
+
+
+def check_file(path, description):
+    """Print whether the given file path exists."""
+    if os.path.exists(path):
+        print(f"{description} found: {path}")
+        return True
+    else:
+        print(f"{description} NOT FOUND: {path}")
+        return False
 
 
 def load_region_lookup(conn):
@@ -326,6 +336,11 @@ def main():
     timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
     output_path = os.path.join(BASE_DIR, f'Website_Dashboard_Output_{timestamp}.xlsx')
     os.makedirs(BASE_DIR, exist_ok=True)
+    # Check that required input files are present
+    check_file(PRICING_CSV, 'Pricing CSV')
+    check_file(PRODUCTS_CSV, 'Products CSV')
+    check_file(IMAGES_CSV, 'Images CSV')
+    check_file(SAP_LISTINGS_XLSX, 'SAP listings file')
     try:
         conn = pyodbc.connect(CONN_STR)
         region_map = load_region_lookup(conn)


### PR DESCRIPTION
## Summary
- incorporate SAP store listings to compare store count
- highlight mismatched counts
- provide mismatch samples sheet
- adjust column widths and formatting for new column

## Testing
- `python -m py_compile 'Website - Website Dashboard Python.py'`

------
https://chatgpt.com/codex/tasks/task_e_68646fd47b008333b43c974156933167