### PR TITLE
Exclude Special Buy rows from pivot

### DIFF
--- a/Website - Website Dashboard Python.py
+++ b/Website - Website Dashboard Python.py
@@ -613,8 +613,10 @@ def main():
             not_active = group['Available in Stores (Count)'] == 'Not Active in Website Database'
             return group.loc[mask | not_active, 'Sellable ID'].nunique()
 
+        # Exclude Special Buy articles from the BD summary pivot
+        pivot_source = final_df[~final_df['Hierarchy'].str.contains('Special Buy', case=False, na=False)]
         pivot_df = (
-            final_df.groupby('SAP BD')
+            pivot_source.groupby('SAP BD')
             .apply(lambda g: pd.Series({
                 'Product_Count': g['Sellable ID'].nunique(),
                 'No_Image_Count': (g['Image Status'] == 'No Image Online').sum(),


### PR DESCRIPTION
## Summary
- filter `final_df` rows containing `Special Buy` in the `Hierarchy` column
- ensure BD Pivot summarizes only standard hierarchy rows

## Testing
- `python -m py_compile 'Website - Website Dashboard Python.py'`

------
https://chatgpt.com/codex/tasks/task_e_68671c1d3334833396cf804c03998a83